### PR TITLE
Add Deezer to auth cookies and search results

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -20,6 +20,8 @@ const nextConfig = {
     accessTokenDelivery: process.env.accessTokenDelivery,
     spotifyClientID: process.env.spotifyClientID,
     youtubeAPIKey: process.env.youtubeAPIKey,
+    deezerAppID: process.env.deezerAppID,
+    deezerSecret: process.env.deezerSecret,
   },
   distDir: '.next',
 };

--- a/frontend/src/endpoints/deezer.js
+++ b/frontend/src/endpoints/deezer.js
@@ -1,26 +1,38 @@
 import axios from 'axios';
 
 export const deezerAuth = () => {
-  axios({
+  return axios({
     method: 'get',
     url:
       'https://cors-anywhere.herokuapp.com/https://connect.deezer.com/oauth/auth.php',
     params: {
-      app_id: '446022',
-      redirect_uri: 'http://localhost:3000/spotify-auth',
+      app_id: process.env.deezerAppID,
+      redirect_uri: 'http://localhost:3000/auth',
       perms: 'basic_access,email',
     },
-  });
+  }).then((res) => res.headers);
 };
 
-export const searchDeezer = (trackName) => {
+export const fetchDeezerToken = (code) => {
   return axios({
     method: 'get',
-    url: 'https://api.spotify.com/v1/search',
+    url:
+      'https://cors-anywhere.herokuapp.com/https://connect.deezer.com/oauth/access_token.php',
+    params: {
+      app_id: process.env.deezerAppID,
+      secret: process.env.deezerSecret,
+      code: code,
+      output: 'json',
+    },
+  }).then((res) => res.data);
+};
+
+export const searchDeezer = (trackName, token) => {
+  return axios({
+    method: 'get',
+    url: 'https://cors-anywhere.herokuapp.com/https://api.deezer.com/search',
     params: {
       q: trackName,
-      type: 'track',
-      market: 'US',
     },
     headers: {
       Authorization: 'Bearer ' + token,

--- a/frontend/src/endpoints/index.js
+++ b/frontend/src/endpoints/index.js
@@ -7,6 +7,7 @@ export {
   searchSpotifyArtist,
 } from './spotify';
 export { searchYoutube } from './youtube';
+export { deezerAuth, fetchDeezerToken, searchDeezer } from './deezer';
 export {
   postUserLogin,
   postUserSignUp,

--- a/frontend/src/pages/auth.js
+++ b/frontend/src/pages/auth.js
@@ -2,47 +2,53 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { SpotifyAuth, Scopes } from 'react-spotify-auth';
 import { useRouter } from 'next/router';
-import { parseCookies } from 'nookies';
+import { setCookie, parseCookies } from 'nookies';
 import { Button } from 'antd';
+import { deezerAuth, fetchDeezerToken } from '../endpoints';
 
 function SpotifyLaunch() {
-  const router = useRouter();
   const spotifyToken = parseCookies().spotifyAuthToken;
+  const deezerToken = parseCookies().deezerAuthToken;
+  const router = useRouter();
 
-  return (
+  return spotifyToken ? (
+    deezerToken ? (
+      <div>
+        <h1>You are authenticated with Spotify and Deezer!</h1>
+        <Link href="./search">
+          <Button>Start Searching!</Button>
+        </Link>
+      </div>
+    ) : (
+      <div>
+        <h1>You are authenticated with Spotify!</h1>
+        <Button
+          onClick={async (e) => {
+            let headers = await deezerAuth();
+            router.push(headers['x-final-url']);
+            let res = await fetchDeezerToken(router.query.code);
+            setCookie(null, 'deezerAuthToken', res.access_token, {
+              maxAge: 60 * 60 * 1000,
+            });
+          }}
+        >
+          Authenticate with Deezer
+        </Button>
+        <Link href="./search">
+          <Button>Start Searching!</Button>
+        </Link>
+      </div>
+    )
+  ) : (
     <div>
-      {spotifyToken ? (
-        <div>
-          <h1>You are authenticated with Spotify!</h1>
-          <Button>Authenticate with Deezer</Button>
-          <Link href="./search">
-            <Button>Start Searching!</Button>
-          </Link>
-        </div>
-      ) : (
-        <div>
-          <SpotifyAuth
-            redirectUri="http://localhost:3000/auth"
-            clientID={process.env.spotifyClientID}
-            scopes={[Scopes.userReadPrivate, 'user-read-email']} // either style will work
-          />
-          <Button onClick={deezerAuth}>Authenticate with Deezer</Button>
-        </div>
-      )}
+      <SpotifyAuth
+        redirectUri="http://localhost:3000/auth"
+        clientID={process.env.spotifyClientID}
+        scopes={[Scopes.userReadPrivate, 'user-read-email']} // either style will work
+      />
+      <Button>Authenticate with Deezer</Button>
     </div>
   );
 }
 
-function deezerAuth() {
-  axios({
-    method: 'get',
-    url:
-      'https://cors-anywhere.herokuapp.com/https://connect.deezer.com/oauth/auth.php',
-    params: {
-      app_id: '446022',
-      redirect_uri: 'http://localhost:3000/auth',
-      perms: 'basic_access,email',
-    },
-  });
-}
 export default SpotifyLaunch;


### PR DESCRIPTION
Still to be done:

- Alter search results based on whether or not the user has authenticated with spotify/deezer
- Add audio data for each (probably not likely with Deezer, we will just link the play button to the deezer site