### PR TITLE
Search from only authenticated sources & deezer cookie fixes

### DIFF
--- a/frontend/src/pages/auth.js
+++ b/frontend/src/pages/auth.js
@@ -2,14 +2,19 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { SpotifyAuth, Scopes } from 'react-spotify-auth';
 import { useRouter } from 'next/router';
-import { setCookie, parseCookies } from 'nookies';
+import { setCookie, parseCookies, destroyCookie } from 'nookies';
 import { Button } from 'antd';
 import { deezerAuth, fetchDeezerToken } from '../endpoints';
+import _ from 'lodash';
 
 function SpotifyLaunch() {
   const spotifyToken = parseCookies().spotifyAuthToken;
   const deezerToken = parseCookies().deezerAuthToken;
   const router = useRouter();
+  if (deezerToken == 'undefined') {
+    destroyCookie(null, 'deezerAuthToken');
+    deezerToken = null;
+  }
 
   return spotifyToken ? (
     deezerToken ? (

--- a/frontend/src/pages/search.js
+++ b/frontend/src/pages/search.js
@@ -162,20 +162,24 @@ function SpotifyRequests() {
 
 const search = async (val, spotifyToken, deezerToken) => {
   let result = [];
-  let spot = await searchSpotify(val, spotifyToken);
+
+  let spot = spotifyToken ? await searchSpotify(val, spotifyToken) : null;
   let yt = await searchYoutube(val + ' song');
-  let deez = await searchDeezer(val, deezerToken);
-  let spotItems = spot.tracks.items;
+  let deez =
+    deezerToken && deezerToken !== 'undefined'
+      ? await searchDeezer(val, deezerToken)
+      : null;
+
+  let spotItems = spot ? spot.tracks.items : [];
   let ytItems = yt.items;
-  let deezItems = deez.data;
-  console.log(deezItems);
+  let deezItems = deez ? deez.data : [];
 
   let s = 0;
   let y = 0;
   let d = 0;
-  let sDone = false;
+  let sDone = spotItems.length > 0 ? false : true;
   let yDone = false;
-  let dDone = false;
+  let dDone = deezItems.length > 0 ? false : true;
 
   for (
     let i = 0;
@@ -194,7 +198,7 @@ const search = async (val, spotifyToken, deezerToken) => {
       });
       s++;
       if (s == 20) sDone = true;
-    } else if (i % 3 == 1 && !yDone) {
+    } else if ((i % 3 == 1 && !yDone) || (sDone && dDone && !yDone)) {
       result.push({
         name: ytItems[y].snippet.title,
         artist: ytItems[y].snippet.channelTitle,
@@ -217,6 +221,8 @@ const search = async (val, spotifyToken, deezerToken) => {
       });
       d++;
       if (d == 25) dDone = true;
+    } else if (dDone && sDone && yDone) {
+      break;
     }
   }
   return result;


### PR DESCRIPTION
Gonna create a benchmark here with working search page - now it'll only attempt to fetch results from sources you've connected with. Still need to decide the fate of the home screen search page - perhaps we move this there and get rid of the /search page
